### PR TITLE
Object-based, multiprocess, and caching pdet and weight estimator 

### DIFF
--- a/notebooks/semianalytic_VT.ipynb
+++ b/notebooks/semianalytic_VT.ipynb
@@ -469,9 +469,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "modelselect-py37",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "modelselect-py37"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -483,7 +483,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.7.4"
+   "version": "3.8.3"
   }
  },
  "nbformat": 4,

--- a/utils/predict_detection_probabilities.py
+++ b/utils/predict_detection_probabilities.py
@@ -24,85 +24,84 @@ def normalize(x, xmin, xmax, a=0, b=1):
     data_norm = (b-a)*(x-xmin) / (xmax-xmin) + a
     return data_norm
 
+class LVKWeighter(object):
 
-def pdets_from_grid(data, grid, pdet_only=False, chieff=False, **kwargs):
-    """
-    Gives relative weight to each system in `data`
-    based on its proximity to the points on the grid.
+    def prepareData(self, data, fields=['m1', 'q', 'z']):
+                
+        # Set bounds
+        bounds = { field : (np.round(data[field].min(), 5),
+                            np.round(data[field].max(), 5)) for field in fields}
 
-    Each system in `data` should have a primary mass `m1`, mass ratio `q`, and redshift `z`
-    Can also include effective spin by setting chieff=True
+        grids = {}
+        
+        # Normalize and apply logarithms if necessary
+        for field in fields:
 
-    This function will determine detection probabilities using nearest neighbor algorithm
-    in [log(m1), q, log(z), chieff] space
+            # These fields get log grids
+            if field in ['m1', 'z']:
+                grids[field] = normalize(np.log10(data[field]),
+                                         np.log10(bounds[field][0]),
+                                         np.log10(bounds[field][1]))
+            else:
+                grids[field] = normalize(data[field],
+                                         bounds[field][0],
+                                         bounds[field][1])
 
-    Need to specify bounds (based on the trained grid) so that the grid and data get
-    normalized properly
-    """
-    # get values from grid for training
-    pdets = np.asarray(grid['pdet'])
-    m1_grid = np.asarray(grid['m1'])
-    q_grid = np.asarray(grid['q'])
-    z_grid = np.asarray(grid['z'])
-    if chieff:
-        chieff_grid = np.asarray(grid['chieff'])
+        # Return the bounds and normalized and logarithmed grids
+        return (bounds, grids)
+    
+    def __init__(self, grid, chieff=False):
 
-    # get bounds based on grid
-    m1_bounds = (np.round(m1_grid.min(), 5), np.round(m1_grid.max(), 5))
-    q_bounds = (np.round(q_grid.min(), 5), np.round(q_grid.max(), 5))
-    z_bounds = (np.round(z_grid.min(), 5), np.round(z_grid.max(), 5))
-    if chieff:
-        chieff_bounds = (np.round(chieff_grid.min(), 5), np.round(chieff_grid.max(), 5))
+        fields = ['m1', 'q', 'z']
 
-    # normalize to unit cube
-    logm1_grid_norm = normalize(np.log10(m1_grid), np.log10(m1_bounds[0]), np.log10(m1_bounds[1]))
-    q_grid_norm = normalize(q_grid, q_bounds[0], q_bounds[1])
-    logz_grid_norm = normalize(np.log10(z_grid), np.log10(z_bounds[0]), np.log10(z_bounds[1]))
-    if chieff:
-        chieff_grid_norm = normalize(chieff_grid, chieff_bounds[0], chieff_bounds[1])
+        if chieff:
+            fields.append('chieff')
 
-    # train nearest neighbor algorithm
-    if chieff:
-        X = np.transpose(np.vstack([logm1_grid_norm, q_grid_norm, logz_grid_norm, chieff_grid_norm]))
-    else:
-        X = np.transpose(np.vstack([logm1_grid_norm, q_grid_norm, logz_grid_norm]))
-    y = np.transpose(np.atleast_2d(pdets))
-    nbrs = KNeighborsRegressor(n_neighbors=10, weights='distance', algorithm='ball_tree', leaf_size=30, p=2, metric='minkowski')
-    nbrs.fit(X, y)
+        # Normalize and logarithm the data
+        bounds, grids = self.prepareData(grid, fields)
+        
+        # Train nearest neighbor algorithm
+        X = np.transpose(np.vstack(list(grids.values())))
+        y = np.transpose(np.atleast_2d(grid['pdet']))
 
-    # get values from dataset and normalize
-    m1_data = np.asarray(data['m1'])
-    q_data = np.asarray(data['q'])
-    z_data = np.asarray(data['z'])
-    if chieff:
-        chieff_data = np.asarray(data['chieff'])
+        # This is the only object we need to persist
+        self.nbrs = KNeighborsRegressor(n_neighbors=10, weights='distance', algorithm='ball_tree', leaf_size=30, p=2, metric='minkowski')
+        self.nbrs.fit(X, y)
 
-    logm1_data_norm = normalize(np.log10(m1_data), np.log10(m1_bounds[0]), np.log10(m1_bounds[1]))
-    q_data_norm = normalize(q_data, q_bounds[0], q_bounds[1])
-    logz_data_norm = normalize(np.log10(z_data), np.log10(z_bounds[0]), np.log10(z_bounds[1]))
-    if chieff:
-        chieff_data_norm = normalize(chieff_data, chieff_bounds[0], chieff_bounds[1])
+    # Perform the estimation
+    def estimate(self, data, chieff=False, pdet_only=False, **kwargs):
 
-    # get pdets for the testing data
-    if chieff:
-        X_fit = np.transpose(np.vstack([logm1_data_norm, q_data_norm,
-                                        logz_data_norm, chieff_data_norm]))
-    else:
-        X_fit = np.transpose(np.vstack([logm1_data_norm,
-                                        q_data_norm, logz_data_norm]))
-    pdets = nbrs.predict(X_fit).flatten()
-    assert all([((p<=1) & (p>=0)) for p in pdets]), 'pdet is not between 0 and 1'
+        fields = ['m1', 'q', 'z']
 
+        if chieff:
+            fields.append('chieff')
 
-    if pdet_only==True:
-        return pdets
-    else:
-        # cosmological VT term for fitted data
-        if 'cosmo' in kwargs:
-            cosmo = kwargs['cosmo']
+        # Preprocess the data
+        bounds, grids = self.prepareData(data, fields)
+
+        # Get it ready to go 
+        X_fit = np.transpose(np.vstack(list(grids.values())))
+
+        # Use the persisted trained object
+        pdets = self.nbrs.predict(X_fit).flatten()
+        print(pdets)
+        
+        assert all([((p<=1) & (p>=0)) for p in pdets]), 'pdet is not between 0 and 1'
+
+        if pdet_only==True:
+            return pdets
         else:
-            cosmo = Planck18
-        cosmo_weight = cosmo.differential_comoving_volume(z_data) * (1+z_data)**(-1.0)
-        combined_weight = pdets * cosmo_weight.value
-        #combined_weight /= np.sum(combined_weight)
-        return pdets, combined_weight
+            # cosmological VT term for fitted data
+            if 'cosmo' in kwargs:
+                cosmo = kwargs['cosmo']
+            else:
+                cosmo = Planck18
+
+            cosmo_weight = cosmo.differential_comoving_volume(data['z']).value * (1+data['z'])**(-1.0)
+            print(cosmo_weight)
+            
+            combined_weight = pdets * cosmo_weight
+            #combined_weight /= np.sum(combined_weight)
+
+            print(combined_weight)
+            return pdets, combined_weight


### PR DESCRIPTION
Implements the core functionality in `pdets_from_grid()` as a persistent-state object.  It will cache the underlying trained regression model, so that training the model only needs to happen on the first call.  Subsequent evaluation of the model can also be distributed across a `multiprocessing.Pool`.  Multiprocessing can be memory intensive, because every child needs a copy of the trained regressor, and that's ~350MB.  Because the regressor is complicated, getting the memory consumption down will probably require something like `map_coordinates()` with a `shared_memory` `numpy` array.  If this approximation scheme delivers the necessarily accuracy, it would likely be 10-100x faster in addition to consuming 1/cores less memory.

Usage example:
```python
from selection_effects.utils.predict_detection_probabilities import LVKWeighter

# Initialize the object with "filename:key" string
# Defaults to loading a cached version if present
lvk = LVKWeighter("pdets_grid.hdf5:O3actual_H1L1V1")

# Estimate with some data
with multiprocessing.Pool(10) as p:
  data['pdet'], data['weight'] = lvk.estimate(data, pool=p)
```


